### PR TITLE
update timeout.go

### DIFF
--- a/example/normal.go
+++ b/example/normal.go
@@ -11,6 +11,15 @@ import (
 	"time"
 )
 
+func AccessLog() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		log.Println("[start]AccessLog")
+		ctx.Next()
+		log.Println("[end]AccessLog")
+	}
+}
+
+
 func main() {
 
 	// create new gin without any middleware
@@ -30,7 +39,7 @@ func main() {
 	engine.GET("/short", short)
 
 	// create a handler that will last 5 seconds
-	engine.GET("/long", long)
+	engine.GET("/long", AccessLog(), long)
 
 	// create a handler that will last 5 seconds but can be canceled.
 	engine.GET("/long2", long2)
@@ -50,7 +59,11 @@ func short(c *gin.Context) {
 }
 
 func long(c *gin.Context) {
+	fmt.Println("handler-long1, do something...")
 	time.Sleep(3 * time.Second)
+	fmt.Println("handler-long2, do something...")
+	time.Sleep(3 * time.Second)
+	fmt.Println("handler-long3, do something...")
 	c.JSON(http.StatusOK, gin.H{"hello": "long"})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/vearne/gin-timeout
 
 go 1.16
 
-require github.com/gin-gonic/gin v1.7.0
+require github.com/gin-gonic/gin v1.7.3

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.7.0 h1:jGB9xAJQ12AIGNB4HguylppmDK1Am9ppF7XnGXXJuoU=
 github.com/gin-gonic/gin v1.7.0/go.mod h1:jD2toBW3GZUr5UMcdrwQA10I7RuaFOl/SGeDjXkfUtY=
+github.com/gin-gonic/gin v1.7.3 h1:aMBzLJ/GMEYmv1UWs2FFTcPISLrQH2mRgL9Glz8xows=
+github.com/gin-gonic/gin v1.7.3/go.mod h1:jD2toBW3GZUr5UMcdrwQA10I7RuaFOl/SGeDjXkfUtY=
 github.com/go-playground/assert/v2 v2.0.1 h1:MsBgLAaY856+nPRTKrp3/OZK38U/wa0CcBYNjji3q3A=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=

--- a/vendor/github.com/gin-gonic/gin/CHANGELOG.md
+++ b/vendor/github.com/gin-gonic/gin/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Gin ChangeLog
 
+## Gin v1.7.3
+
+* fix level 1 router match [#2767](https://github.com/gin-gonic/gin/issues/2767), [#2796](https://github.com/gin-gonic/gin/issues/2796)
+## Gin v1.7.2
+
+### BUGFIXES
+
+* Fix conflict between param and exact path [#2706](https://github.com/gin-gonic/gin/issues/2706). Close issue [#2682](https://github.com/gin-gonic/gin/issues/2682) [#2696](https://github.com/gin-gonic/gin/issues/2696).
+
+## Gin v1.7.1
+
+### BUGFIXES
+
+* fix: data race with trustedCIDRs from [#2674](https://github.com/gin-gonic/gin/issues/2674)([#2675](https://github.com/gin-gonic/gin/pull/2675))
+
 ## Gin v1.7.0
 
 ### BUGFIXES

--- a/vendor/github.com/gin-gonic/gin/context.go
+++ b/vendor/github.com/gin-gonic/gin/context.go
@@ -767,8 +767,6 @@ func (c *Context) RemoteIP() (net.IP, bool) {
 		return nil, false
 	}
 
-	trustedCIDRs, _ := c.engine.prepareTrustedCIDRs()
-	c.engine.trustedCIDRs = trustedCIDRs
 	if c.engine.trustedCIDRs != nil {
 		for _, cidr := range c.engine.trustedCIDRs {
 			if cidr.Contains(remoteIP) {

--- a/vendor/github.com/gin-gonic/gin/version.go
+++ b/vendor/github.com/gin-gonic/gin/version.go
@@ -5,4 +5,4 @@
 package gin
 
 // Version is the current gin framework's version.
-const Version = "v1.7.0"
+const Version = "v1.7.3"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,6 @@
 # github.com/gin-contrib/sse v0.1.0
 github.com/gin-contrib/sse
-# github.com/gin-gonic/gin v1.7.0
+# github.com/gin-gonic/gin v1.7.3
 ## explicit
 github.com/gin-gonic/gin
 github.com/gin-gonic/gin/binding


### PR DESCRIPTION
fatal error: concurrent map read and map write

Because gin use sync.pool to reuse gin.Context and middleware-timeout fork a child goroutine. There may be an extreme scenario, the child goroutine is using gin.Context, but it has put into the pool.