### PR TITLE
Fix: allow Gin to write default body for HTTP 404

### DIFF
--- a/timeout.go
+++ b/timeout.go
@@ -106,9 +106,10 @@ func Timeout(opts ...Option) gin.HandlerFunc {
 			}
 
 			tw.ResponseWriter.WriteHeader(tw.code)
-			_, err = tw.ResponseWriter.Write(buffer.Bytes())
-			if err != nil {
-				panic(err)
+			if b := buffer.Bytes(); len(b) > 0 {
+				if _, err = tw.ResponseWriter.Write(b); err != nil {
+					panic(err)
+				}
 			}
 			buffpool.PutBuff(buffer)
 		}


### PR DESCRIPTION
This PR allows Gin to write default body for HTTP 404 and 405 when timeout middleware is installed.

Current behavior:

```
Original Gin response:

➜  ~ curl -i http://localhost:8001/healthz
HTTP/1.1 404 Not Found
Content-Type: text/plain
Date: Wed, 08 Mar 2023 17:27:25 GMT
Content-Length: 18

404 page not found%

With timeout middleware installed:

➜  ~ curl -i http://localhost:8001/healthz
HTTP/1.1 404 Not Found
Date: Wed, 08 Mar 2023 17:26:25 GMT
Content-Length: 0
```